### PR TITLE
Fix/53 Adds deselection option

### DIFF
--- a/app/assets/scripts/views/location-edit.js
+++ b/app/assets/scripts/views/location-edit.js
@@ -196,7 +196,6 @@ class LocationEdit extends React.Component {
     }
 
     const onChange = (val) => {
-      console.log('val', val.key)
       this.propUpdate(key, val.key);
     };
 
@@ -475,17 +474,19 @@ class LocationEdit extends React.Component {
 
   validateForm (metadata) {
     const { match } = this.props;
+    const isNotRequired = (key) => {
+      const requiredKeys = ['id', 'instrument', 'name'];
+      return requiredKeys.filter(requiredKey => (requiredKey === key));
+    };
     // Sets metadata id from props if none exists
     if (!metadata.id) metadata.id = match.params.id;
     // Applies error status to form elements that don't meet validation
     // criteria from openaq-data-format
-    console.log('metadata', metadata);
     // Removes metadata property with value of ''. In the future,
     // this should be replaced in favor of validation that accepts '' as a valid no-option
-    Object.keys(metadata).forEach((key) => (metadata[key] === '') && delete metadata[key]);
-    console.log('metadata2', metadata);
+    Object.keys(metadata).forEach((key) => (metadata[key] === '' && !isNotRequired(key).length) && delete metadata[key]);
+    // Runs validation from open-aq-format
     const { errors } = validate('location', metadata);
-    console.log('errors', errors);
     // Lists form item and error type for validation error occuring on an instrument
     const errorState = { instruments: [] };
 

--- a/app/assets/scripts/views/location-edit.js
+++ b/app/assets/scripts/views/location-edit.js
@@ -190,6 +190,10 @@ class LocationEdit extends React.Component {
     let options;
     if (availableValues) {
       options = availableValues.map((k) => ({ key: k, label: k }));
+
+      // Adds an option for users to deselect item
+      const deselectValue = { key: '', label: 'not applicable' };
+      options.unshift(deselectValue);
     }
 
     const onChange = (val) => {
@@ -471,10 +475,16 @@ class LocationEdit extends React.Component {
 
   validateForm (metadata) {
     const { match } = this.props;
+    // Sets metadata id from props if none exists
     if (!metadata.id) metadata.id = match.params.id;
+    // Applies error status to form elements that don't meet validation
+    // criteria from openaq-data-format
     const { errors } = validate('location', metadata);
+    console.log('errors', errors);
+    // Lists form item and error type for validation error occuring on an instrument
     const errorState = { instruments: [] };
 
+    // Sets error state and message if error is triggered above
     if (errors && errors.length) {
       errors.forEach((error) => {
         const key = this.formatKey(error.property);

--- a/app/assets/scripts/views/location-edit.js
+++ b/app/assets/scripts/views/location-edit.js
@@ -87,6 +87,11 @@ class LocationEdit extends React.Component {
     }
   }
 
+  /**
+   * @param {string} key - form input label.
+   * @param {number} value - form input value.
+   * @return {function} action to update metadata object with type.
+   */
   propUpdate (key, value) {
     const metadata = Object.assign({ instruments: [] }, this.props.location.metadata);
     const data = keypath.set(metadata, key, value);
@@ -182,6 +187,11 @@ class LocationEdit extends React.Component {
     );
   }
 
+  /**
+   * @param {string} key - form input label.
+   * @param {number} value - form input value.
+   * @param {object} prop - section properties used to populate dropdown.
+   */
   renderSelectProp (key, value, prop) {
     const { required, title } = prop;
     const availableValues = prop.enum;
@@ -472,25 +482,25 @@ class LocationEdit extends React.Component {
       .replace(']', '');
   }
 
+  /**
+   * @param {object} metadata - updated data from form input to be validated.
+   * Sets metadata id.
+   * Removes empty values that are not required.
+   * Runs validation from open-aq-format.
+   * Sets error state and message if triggered from validation.
+   */
   validateForm (metadata) {
     const { match } = this.props;
+    if (!metadata.id) metadata.id = match.params.id;
+    // In the future, this should be replaced in favor of validation that accepts '' as a valid no-option.
     const isNotRequired = (key) => {
       const requiredKeys = ['id', 'instrument', 'name'];
       return requiredKeys.filter(requiredKey => (requiredKey === key));
     };
-    // Sets metadata id from props if none exists
-    if (!metadata.id) metadata.id = match.params.id;
-    // Applies error status to form elements that don't meet validation
-    // criteria from openaq-data-format
-    // Removes metadata property with value of ''. In the future,
-    // this should be replaced in favor of validation that accepts '' as a valid no-option
     Object.keys(metadata).forEach((key) => (metadata[key] === '' && !isNotRequired(key).length) && delete metadata[key]);
-    // Runs validation from open-aq-format
     const { errors } = validate('location', metadata);
-    // Lists form item and error type for validation error occuring on an instrument
     const errorState = { instruments: [] };
 
-    // Sets error state and message if error is triggered above
     if (errors && errors.length) {
       errors.forEach((error) => {
         const key = this.formatKey(error.property);

--- a/app/assets/scripts/views/location-edit.js
+++ b/app/assets/scripts/views/location-edit.js
@@ -90,7 +90,6 @@ class LocationEdit extends React.Component {
   propUpdate (key, value) {
     const metadata = Object.assign({ instruments: [] }, this.props.location.metadata);
     const data = keypath.set(metadata, key, value);
-    this.validateForm(data);
     this.props.updateMetadata(data);
   }
 
@@ -192,11 +191,12 @@ class LocationEdit extends React.Component {
       options = availableValues.map((k) => ({ key: k, label: k }));
 
       // Adds an option for users to deselect item
-      const deselectValue = { key: '', label: 'not applicable' };
+      const deselectValue = { key: '', label: 'Select One' };
       options.unshift(deselectValue);
     }
 
     const onChange = (val) => {
+      console.log('val', val.key)
       this.propUpdate(key, val.key);
     };
 
@@ -479,6 +479,11 @@ class LocationEdit extends React.Component {
     if (!metadata.id) metadata.id = match.params.id;
     // Applies error status to form elements that don't meet validation
     // criteria from openaq-data-format
+    console.log('metadata', metadata);
+    // Removes metadata property with value of ''. In the future,
+    // this should be replaced in favor of validation that accepts '' as a valid no-option
+    Object.keys(metadata).forEach((key) => (metadata[key] === '') && delete metadata[key]);
+    console.log('metadata2', metadata);
     const { errors } = validate('location', metadata);
     console.log('errors', errors);
     // Lists form item and error type for validation error occuring on an instrument


### PR DESCRIPTION
#53  I added an option of 'Select One' at the top of the list. If selected, the 'Select One' option will add an empty value for that form option.

An empty string is not an acceptable value for the current validation set up as-is. I think an ideal fix would include an update of the validation-format [here](https://github.com/openaq/openaq-data-format/blob/master/index.js) to allow for an empty string to be a valid value on optional properties.

In the meantime, I added a few lines to the validate function to 
- ensure the changes is not on a required field
- remove the property with a value of an empty string

The goal of this is to match the format of undefined metadata values. (Currently if there is no value for say site-type, it doesn't exist on the metadata.

Part of getting this to work included moving validation to occur only on save. ( #52 )
@sethvincent I'm not sure I understand the value of validating on propUpdate. So my removal of the validate on that function might incur some unintended consequences that I can't identify at the time being. 

If that is the case, let's discuss this further and I'll address the issue of 'Validate on Save' in a different PR to precede this.