### PR TITLE
Feature/59 checkbox tooltip

### DIFF
--- a/app/assets/scripts/components/form/form-input.js
+++ b/app/assets/scripts/components/form/form-input.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Asterisk from './asterisk';
 
-const FormInput = ({ title, type, value, onChange, isTooltopShowing, description, required }) => {
+const FormInput = ({ title, type, value, onChange, description, required }) => {
   return (
     <React.Fragment>
       <label className='form__label'>
@@ -15,12 +15,10 @@ const FormInput = ({ title, type, value, onChange, isTooltopShowing, description
           value={value}
           onChange={onChange}
         />
-        {isTooltopShowing ? (
-          <div className='tooltip'>
-            <i className='tooltip-button edit-box-delete collecticons collecticons-circle-information'/>
-            <span className='tooltip-info'>{description}</span>
-          </div>
-        ) : null }
+        <div className='tooltip'>
+          <i className='tooltip-button edit-box-delete collecticons collecticons-circle-information'/>
+          <span className='tooltip-info'>{description}</span>
+        </div>
       </div>
     </React.Fragment>
   );

--- a/app/assets/scripts/views/location-edit.js
+++ b/app/assets/scripts/views/location-edit.js
@@ -81,7 +81,7 @@ class LocationEdit extends React.Component {
 
   componentDidMount () {
     const { match: { params: { id } } } = this.props;
-    
+
     if (!this.props.location || this.props.location.id || this.props.location.id !== id) {
       this.props.getMetadata(id);
     }

--- a/app/assets/scripts/views/location-edit.js
+++ b/app/assets/scripts/views/location-edit.js
@@ -8,7 +8,7 @@ import parse from 'date-fns/parse';
 import { schemas, validate } from 'openaq-data-format';
 
 import Header from '../components/header';
-import Map from '../components/map';
+import MapEdit from '../components/map-edit';
 import ErrorMessage from '../components/error-message';
 import FormInput from '../components/form/form-input';
 import Asterisk from '../components/form/asterisk';
@@ -375,11 +375,16 @@ class LocationEdit extends React.Component {
       ? [metadata.coordinates.longitude, metadata.coordinates.latitude]
       : [0, 0];
 
+    const onChange = (coordinates) => {
+      this.propUpdate('coordinates', coordinates);
+    };
+
     return (
-      <Map
+      <MapEdit
         zoom={10}
         width={300}
         coordinates={coordinates}
+        onChange={onChange}
       />
     );
   }

--- a/app/assets/scripts/views/location-edit.js
+++ b/app/assets/scripts/views/location-edit.js
@@ -81,7 +81,7 @@ class LocationEdit extends React.Component {
 
   componentDidMount () {
     const { match: { params: { id } } } = this.props;
-
+    
     if (!this.props.location || this.props.location.id || this.props.location.id !== id) {
       this.props.getMetadata(id);
     }
@@ -257,7 +257,6 @@ class LocationEdit extends React.Component {
               description={prop.description}
               required={prop.required}
               type='text'
-              isTooltopShowing={true}
             />);
         }
       case 'integer':
@@ -269,7 +268,6 @@ class LocationEdit extends React.Component {
             description={prop.description}
             required={prop.required}
             type='number'
-            isTooltopShowing={true}
           />);
       case 'array':
         return this.renderMultiSelectProp(key, value, prop);
@@ -282,7 +280,6 @@ class LocationEdit extends React.Component {
             description={prop.description}
             required={prop.required}
             type='checkbox'
-            isTooltopShowing={false}
           />
         );
     }

--- a/app/assets/scripts/views/location-edit.js
+++ b/app/assets/scripts/views/location-edit.js
@@ -362,6 +362,9 @@ class LocationEdit extends React.Component {
     });
   }
 
+  /**
+   * @return {class} Displays class component non-editable map with coordinates from metadata.
+   */
   renderMap () {
     const { location } = this.props;
     const { metadata } = location;

--- a/app/assets/scripts/views/location-edit.js
+++ b/app/assets/scripts/views/location-edit.js
@@ -8,7 +8,7 @@ import parse from 'date-fns/parse';
 import { schemas, validate } from 'openaq-data-format';
 
 import Header from '../components/header';
-import MapEdit from '../components/map-edit';
+import Map from '../components/map';
 import ErrorMessage from '../components/error-message';
 import FormInput from '../components/form/form-input';
 import Asterisk from '../components/form/asterisk';
@@ -375,16 +375,11 @@ class LocationEdit extends React.Component {
       ? [metadata.coordinates.longitude, metadata.coordinates.latitude]
       : [0, 0];
 
-    const onChange = (coordinates) => {
-      this.propUpdate('coordinates', coordinates);
-    };
-
     return (
-      <MapEdit
+      <Map
         zoom={10}
         width={300}
         coordinates={coordinates}
-        onChange={onChange}
       />
     );
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9636,7 +9636,7 @@
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-faker": {
-      "version": "github:json-schema-faker/json-schema-faker#4d356f818599b8a5f90ef0f50914f4e0bfc6a10e",
+      "version": "github:json-schema-faker/json-schema-faker#a994a498cb730560f957db3d70019ba9e8c8692b",
       "from": "github:json-schema-faker/json-schema-faker#develop",
       "dev": true,
       "requires": {
@@ -11293,7 +11293,7 @@
       }
     },
     "openaq-data-format": {
-      "version": "github:openaq/openaq-data-format#1d4ee7cdd6dd2cd08f43134ea6000bda2f95500c",
+      "version": "github:openaq/openaq-data-format#cce3a261aeb97c1e2463c51504aa84d71c271e73",
       "from": "github:openaq/openaq-data-format#master",
       "requires": {
         "jsonschema": "^1.2.4"


### PR DESCRIPTION
#59 Adds tooltip to checkboxes

Justification:
This will give clarity to the user that they can mark the coordinates as incorrect and provide instruction on how to fix the error in the notes

The updates for the tooltip text and the addition of the coordinate error was made here:
https://github.com/openaq/openaq-data-format/pull/19

Open tooltip for error checkmark 
![image](https://user-images.githubusercontent.com/20410256/65269360-05232280-dae7-11e9-8427-f707ca04b036.png)

Updated tooltip text for notes 
![image](https://user-images.githubusercontent.com/20410256/65269432-284dd200-dae7-11e9-8e23-3dc91eabe592.png)
