### PR TITLE
changes reference to map

### DIFF
--- a/app/assets/scripts/views/location-edit.js
+++ b/app/assets/scripts/views/location-edit.js
@@ -8,7 +8,7 @@ import parse from 'date-fns/parse';
 import { schemas, validate } from 'openaq-data-format';
 
 import Header from '../components/header';
-import MapEdit from '../components/map-edit';
+import Map from '../components/map';
 import ErrorMessage from '../components/error-message';
 import FormInput from '../components/form/form-input';
 import Asterisk from '../components/form/asterisk';
@@ -384,7 +384,7 @@ class LocationEdit extends React.Component {
     };
 
     return (
-      <MapEdit
+      <Map
         zoom={10}
         width={300}
         coordinates={coordinates}


### PR DESCRIPTION
#71 The location-edit now references map instead of map-edit

The map-edit component was deleted in #66 and was replaced with the map component.

It appears that the reference to Map-Edit was added back in mistakenly through a rebase to an old version of the develop branch.

This pr references the correct map component and should fix the reference error.